### PR TITLE
Use env specific render instead of global render

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,13 +28,12 @@ module.exports = (path, opts) => {
   return function view(ctx, next) {
     if (ctx.render) return next();
 
-    const render = nunjucks.render;
     // Render `view` with `locals` and `koa.ctx.state`.
     ctx.render = (view, locals) => {
       const state = Object.assign({}, ctx.state, locals);
 
       return new Promise((res, rej) => {
-        render(view + ext, state, (err, html) => {
+        env.render(view + ext, state, (err, html) => {
           if (err) return rej(err);
           // Render with response content-type, fallback to text/html
           ctx.type = ctx.type || 'text/html';


### PR DESCRIPTION
Solves a problem when multiple instances of Nunjucks are being used.

From the Nunjucks docs: `Warning: The simple API (above; e.g. nunjucks.render) always uses the configuration from the most recent call to nunjucks.configure. Since this is implicit and can result in unexpected side effects, use of the simple API is discouraged in most cases (especially if configure is used); instead, explicitly create an environment using var env = nunjucks.configure(...) and then call env.render(...) etc.`